### PR TITLE
Basic tracing using OpenTelemetry introduced

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Session.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Session.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.driver.core;
 
 import com.datastax.driver.core.exceptions.AuthenticationException;
@@ -20,6 +26,7 @@ import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.datastax.driver.core.exceptions.QueryExecutionException;
 import com.datastax.driver.core.exceptions.QueryValidationException;
 import com.datastax.driver.core.exceptions.UnsupportedFeatureException;
+import com.datastax.driver.core.tracing.TracingInfoFactory;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.io.Closeable;
 import java.util.Collection;
@@ -40,6 +47,21 @@ import java.util.Map;
  * names in queries.
  */
 public interface Session extends Closeable {
+
+  /**
+   * Sets desired factory for tracing information for this Session. By default it is {@link
+   * com.datastax.driver.core.tracing.NoopTracingInfoFactory}
+   *
+   * @param tracingInfoFactory the factory to be set for this Session.
+   */
+  void setTracingInfoFactory(TracingInfoFactory tracingInfoFactory);
+
+  /**
+   * The tracingInfo factory class used by this Session.
+   *
+   * @return the factory used currently by this Session.
+   */
+  TracingInfoFactory getTracingInfoFactory();
 
   /**
    * The keyspace to which this Session is currently logged in, if any.

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.core.tracing;
+
+import com.datastax.driver.core.ConsistencyLevel;
+
+public class NoopTracingInfoFactory implements TracingInfoFactory {
+
+  private static class NoopTracingInfo implements TracingInfo {
+    @Override
+    public void setNameAndStartTime(String name) {}
+
+    @Override
+    public void setConsistencyLevel(ConsistencyLevel consistency) {}
+
+    @Override
+    public void setStatementType(String statementType) {}
+
+    @Override
+    public void recordException(Exception exception) {}
+
+    @Override
+    public void setStatus(StatusCode code, String description) {}
+
+    @Override
+    public void setStatus(StatusCode code) {}
+
+    @Override
+    public void tracingFinished() {}
+  }
+
+  private static final NoopTracingInfo INSTANCE = new NoopTracingInfo();
+
+  @Override
+  public TracingInfo buildTracingInfo() {
+    return INSTANCE;
+  }
+
+  @Override
+  public TracingInfo buildTracingInfo(TracingInfo parent) {
+    return new NoopTracingInfo();
+  }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.core.tracing;
+
+import com.datastax.driver.core.ConsistencyLevel;
+
+/**
+ * An abstraction layer over instrumentation library API, corresponding to a logical span in the
+ * trace.
+ */
+public interface TracingInfo {
+
+  /** Final status of the traced execution. */
+  enum StatusCode {
+    OK,
+    ERROR,
+  }
+
+  /**
+   * Starts a span corresponding to this {@link TracingInfo} object. Must be called exactly once,
+   * before any other method, at the beginning of the traced execution.
+   *
+   * @param name the name given to the span being created.
+   */
+  void setNameAndStartTime(String name);
+
+  /**
+   * Adds provided consistency level to the trace.
+   *
+   * @param consistency the consistency level to be set.
+   */
+  void setConsistencyLevel(ConsistencyLevel consistency);
+
+  /**
+   * Adds provided statement type to the trace.
+   *
+   * @param statementType the statementType to be set.
+   */
+  void setStatementType(String statementType);
+
+  /**
+   * Records in the trace that the provided exception occured.
+   *
+   * @param exception the exception to be recorded.
+   */
+  void recordException(Exception exception);
+
+  /**
+   * Sets the final status of the traced execution.
+   *
+   * @param code the status code to be set.
+   */
+  void setStatus(StatusCode code);
+
+  /**
+   * Sets the final status of the traced execution, with additional description.
+   *
+   * @param code the status code to be set.
+   * @param description the additional description of the status.
+   */
+  void setStatus(StatusCode code, String description);
+
+  /** Must be always called exactly once at the logical end of traced execution. */
+  void tracingFinished();
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfoFactory.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfoFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.core.tracing;
+
+/** Factory of trace info objects. */
+public interface TracingInfoFactory {
+
+  /** Creates new trace info object, inheriting global context. */
+  TracingInfo buildTracingInfo();
+
+  /**
+   * Creates new trace info object, inheriting context from provided another trace info object.
+   *
+   * @param parent the trace info object to be set as the parent of newly created trace info object.
+   */
+  TracingInfo buildTracingInfo(TracingInfo parent);
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
@@ -27,6 +27,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import com.datastax.driver.core.exceptions.InvalidQueryException;
+import com.datastax.driver.core.tracing.TracingInfoFactory;
 import com.datastax.driver.core.utils.CassandraVersion;
 import com.google.common.base.Function;
 import com.google.common.base.Throwables;
@@ -291,6 +292,16 @@ public class AsyncQueryTest extends CCMTestsSupport {
       // test a custom call to checkNotInEventLoop()
       checkNotInEventLoop();
       return executeAsync(statement).getUninterruptibly();
+    }
+
+    @Override
+    public void setTracingInfoFactory(TracingInfoFactory tracingInfoFactory) {
+      session.setTracingInfoFactory(tracingInfoFactory);
+    }
+
+    @Override
+    public TracingInfoFactory getTracingInfoFactory() {
+      return session.getTracingInfoFactory();
     }
 
     @Override

--- a/driver-examples/README.md
+++ b/driver-examples/README.md
@@ -8,3 +8,14 @@ Apache Cassandra.
 Unless otherwise stated, all examples assume that you have a single-node Cassandra 3.0 cluster 
 listening on localhost:9042.
 
+Before running examples, make sure you installed repo artifacts (in root driver directory):
+```
+mvn install -q -Dmaven.test.skip=true
+```
+
+To conveniently run the example showing OpenTelemetry integration (ZipkinConfiguration),
+you can use the provided ```docker-compose.yaml``` file:
+```
+docker compose up
+./runOpenTelemetryExample.sh
+```

--- a/driver-examples/docker-compose.yaml
+++ b/driver-examples/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: '3.4'
+
+services:
+    zipkin:
+        image: openzipkin/zipkin
+        ports:
+            - "9411:9411"
+    scylla_node:
+        image: scylladb/scylla
+        ports:
+            - "9042:9042"
+        command: "--smp 1"

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -48,6 +48,11 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>com.scylladb</groupId>
+            <artifactId>scylla-driver-opentelemetry</artifactId>
+        </dependency>
+
         <!--Jackson-->
 
         <dependency>
@@ -134,6 +139,26 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
 
+        <!-- OpenTelemetry -->
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>1.9.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>1.9.0-alpha</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-zipkin</artifactId>
+            <version>1.9.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -181,6 +206,15 @@
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
 

--- a/driver-examples/runOpenTelemetryExample.sh
+++ b/driver-examples/runOpenTelemetryExample.sh
@@ -1,0 +1,1 @@
+mvn -q exec:java -Dexec.mainClass="com.datastax.driver.examples.opentelemetry.ZipkinUsage"

--- a/driver-examples/src/main/java/com/datastax/driver/examples/opentelemetry/OpenTelemetryConfiguration.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/opentelemetry/OpenTelemetryConfiguration.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.examples.opentelemetry;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+
+/** Example showing how to configure OpenTelemetry for tracing with Scylla Java Driver. */
+class OpenTelemetryConfiguration {
+  private static final String SERVICE_NAME = "Scylla Java driver";
+
+  public static OpenTelemetry initialize(SpanExporter spanExporter) {
+    Resource serviceNameResource =
+        Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, SERVICE_NAME));
+
+    // Set to process the spans by the spanExporter.
+    final SdkTracerProvider tracerProvider =
+        SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+            .setResource(Resource.getDefault().merge(serviceNameResource))
+            .build();
+    OpenTelemetrySdk openTelemetry =
+        OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).buildAndRegisterGlobal();
+
+    // Add a shutdown hook to shut down the SDK.
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                new Runnable() {
+                  @Override
+                  public void run() {
+                    tracerProvider.close();
+                  }
+                }));
+
+    // Return the configured instance so it can be used for instrumentation.
+    return openTelemetry;
+  }
+
+  public static OpenTelemetry initializeForZipkin(String ip, int port) {
+    String endpointPath = "/api/v2/spans";
+    String httpUrl = String.format("http://%s:%s", ip, port);
+
+    SpanExporter exporter =
+        ZipkinSpanExporter.builder().setEndpoint(httpUrl + endpointPath).build();
+
+    return initialize(exporter);
+  }
+}

--- a/driver-examples/src/main/java/com/datastax/driver/examples/opentelemetry/ZipkinUsage.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/opentelemetry/ZipkinUsage.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+package com.datastax.driver.examples.opentelemetry;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.tracing.TracingInfoFactory;
+import com.datastax.driver.opentelemetry.OpenTelemetryTracingInfoFactory;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+
+/**
+ * Creates a keyspace and tables, and loads some data into them. Sends OpenTelemetry tracing data to
+ * Zipkin tracing backend
+ *
+ * <p>Preconditions: - a Scylla cluster is running and accessible through the contacts points
+ * identified by CONTACT_POINTS and PORT and Zipkin backend is running and accessible through the
+ * contacts points identified by ZIPKIN_CONTACT_POINT and ZIPKIN_PORT.
+ *
+ * <p>Side effects: - creates a new keyspace "simplex" in the cluster. If a keyspace with this name
+ * already exists, it will be reused; - creates two tables "simplex.songs" and "simplex.playlists".
+ * If they exist already, they will be reused; - inserts a row in each table.
+ */
+public class ZipkinUsage {
+  private static final String CONTACT_POINT = "127.0.0.1";
+  private static final int PORT = 9042;
+
+  private static final String ZIPKIN_CONTACT_POINT = "127.0.0.1";
+  private static final int ZIPKIN_PORT = 9411;
+
+  private Cluster cluster;
+  private Session session;
+
+  private Tracer tracer;
+
+  public static void main(String[] args) {
+    // Workaround for setting ContextStorage to ThreadLocalContextStorage.
+    System.setProperty("io.opentelemetry.context.contextStorageProvider", "default");
+
+    ZipkinUsage client = new ZipkinUsage();
+
+    try {
+      client.connect();
+      client.createSchema();
+      client.loadData();
+      System.out.println(
+          "All requests have been completed. Now you can visit Zipkin at "
+              + "http://"
+              + ZIPKIN_CONTACT_POINT
+              + ":"
+              + ZIPKIN_PORT
+              + " and examine the produced trace.");
+    } finally {
+      client.close();
+    }
+  }
+
+  /** Initiates a connection to the cluster. */
+  public void connect() {
+    cluster = Cluster.builder().addContactPoints(CONTACT_POINT).withPort(PORT).build();
+
+    System.out.printf("Connected to cluster: %s%n", cluster.getMetadata().getClusterName());
+
+    session = cluster.connect();
+
+    OpenTelemetry openTelemetry =
+        OpenTelemetryConfiguration.initializeForZipkin(ZIPKIN_CONTACT_POINT, ZIPKIN_PORT);
+    tracer = openTelemetry.getTracerProvider().get("this");
+    TracingInfoFactory tracingInfoFactory = new OpenTelemetryTracingInfoFactory(tracer);
+    session.setTracingInfoFactory(tracingInfoFactory);
+  }
+
+  /** Creates the schema (keyspace) and tables for this example. */
+  public void createSchema() {
+    Span parentSpan = tracer.spanBuilder("create schema").startSpan();
+    try (Scope parentScope = parentSpan.makeCurrent()) {
+      {
+        Span span = tracer.spanBuilder("create simplex").startSpan();
+        try (Scope scope = span.makeCurrent()) {
+          session.execute(
+              "CREATE KEYSPACE IF NOT EXISTS simplex WITH replication "
+                  + "= {'class':'SimpleStrategy', 'replication_factor':1};");
+
+        } finally {
+          span.end();
+        }
+      }
+      {
+        Span span = tracer.spanBuilder("create simplex.songs").startSpan();
+        try (Scope scope = span.makeCurrent()) {
+          session.executeAsync(
+              "CREATE TABLE IF NOT EXISTS simplex.songs ("
+                  + "id uuid PRIMARY KEY,"
+                  + "title text,"
+                  + "album text,"
+                  + "artist text,"
+                  + "tags set<text>,"
+                  + "data blob"
+                  + ");");
+        } finally {
+          span.end();
+        }
+      }
+      {
+        Span span = tracer.spanBuilder("create simplex.playlists").startSpan();
+        try (Scope scope = span.makeCurrent()) {
+          session.execute(
+              "CREATE TABLE IF NOT EXISTS simplex.playlists ("
+                  + "id uuid,"
+                  + "title text,"
+                  + "album text, "
+                  + "artist text,"
+                  + "song_id uuid,"
+                  + "PRIMARY KEY (id, title, album, artist)"
+                  + ");");
+
+        } finally {
+          span.end();
+        }
+      }
+    } finally {
+      parentSpan.end();
+    }
+  }
+
+  /** Inserts data into the tables. */
+  public void loadData() {
+    Span parentSpan = tracer.spanBuilder("create schema").startSpan();
+    try (Scope parentScope = parentSpan.makeCurrent()) {
+      {
+        {
+          Span span = tracer.spanBuilder("insert simplex.playlists").startSpan();
+          try (Scope scope = span.makeCurrent()) {
+            session.execute(
+                "INSERT INTO simplex.songs (id, title, album, artist, tags) "
+                    + "VALUES ("
+                    + "756716f7-2e54-4715-9f00-91dcbea6cf50,"
+                    + "'La Petite Tonkinoise',"
+                    + "'Bye Bye Blackbird',"
+                    + "'Joséphine Baker',"
+                    + "{'jazz', '2013'})"
+                    + ";");
+          } finally {
+            span.end();
+          }
+        }
+      }
+    } finally {
+      parentSpan.end();
+    }
+  }
+
+  /** Closes the session and the cluster. */
+  public void close() {
+    session.close();
+    cluster.close();
+  }
+}

--- a/driver-opentelemetry/pom.xml
+++ b/driver-opentelemetry/pom.xml
@@ -1,0 +1,116 @@
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!--
+    Copyright (C) 2021 ScyllaDB
+    Modified by ScyllaDB
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.scylladb</groupId>
+        <artifactId>scylla-driver-parent</artifactId>
+        <version>3.10.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>scylla-driver-opentelemetry</artifactId>
+    <name>Java Driver for Scylla and Apache Cassandra - OpenTelemetry integration</name>
+    <description>A extension of Java Driver for Scylla and Apache Cassandra by adding
+        functionality of creating traces and spans in OpenTelemetry format.
+    </description>
+
+    <dependencyManagement>
+
+        <dependencies>
+
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>1.9.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+        </dependencies>
+
+    </dependencyManagement>
+
+    <dependencies>
+
+        <!-- driver dependencies -->
+
+        <dependency>
+            <groupId>com.scylladb</groupId>
+            <artifactId>scylla-driver-core</artifactId>
+        </dependency>
+
+        <!-- OpenTelemetry -->
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>1.9.1</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+
+            <!-- Disable check-jdk6 check for this submodule. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.15</version>
+                <executions>
+                    <execution>
+                        <id>check-jdk6</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>check-jdk8</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+
+    </build>
+
+</project>

--- a/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfo.java
+++ b/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfo.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.opentelemetry;
+
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.tracing.TracingInfo;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+
+public class OpenTelemetryTracingInfo implements TracingInfo {
+  private Span span;
+  private final Tracer tracer;
+  private final Context context;
+  private boolean tracingStarted;
+
+  protected OpenTelemetryTracingInfo(Tracer tracer, Context context) {
+    this.tracer = tracer;
+    this.context = context;
+    tracingStarted = false;
+  }
+
+  public Tracer getTracer() {
+    return tracer;
+  }
+
+  public Context getContext() {
+    return context.with(span);
+  }
+
+  private void assertStarted() {
+    assert tracingStarted : "TracingInfo.setStartTime must be called before any other method";
+  }
+
+  @Override
+  public void setNameAndStartTime(String name) {
+    assert !tracingStarted : "TracingInfo.setStartTime may only be called once.";
+    tracingStarted = true;
+    span = tracer.spanBuilder(name).setParent(context).startSpan();
+  }
+
+  @Override
+  public void setConsistencyLevel(ConsistencyLevel consistency) {
+    assertStarted();
+    span.setAttribute("db.scylla.consistency_level", consistency.toString());
+  }
+
+  @Override
+  public void setStatementType(String statementType) {
+    assertStarted();
+    span.setAttribute("db.scylla.statement_type", statementType);
+  }
+
+  private io.opentelemetry.api.trace.StatusCode mapStatusCode(StatusCode code) {
+    switch (code) {
+      case OK:
+        return io.opentelemetry.api.trace.StatusCode.OK;
+      case ERROR:
+        return io.opentelemetry.api.trace.StatusCode.ERROR;
+    }
+    return null;
+  }
+
+  @Override
+  public void recordException(Exception exception) {
+    assertStarted();
+    span.recordException(exception);
+  }
+
+  @Override
+  public void setStatus(StatusCode code, String description) {
+    assertStarted();
+    span.setStatus(mapStatusCode(code), description);
+  }
+
+  @Override
+  public void setStatus(StatusCode code) {
+    assertStarted();
+    span.setStatus(mapStatusCode(code));
+  }
+
+  @Override
+  public void tracingFinished() {
+    assertStarted();
+    span.end();
+  }
+}

--- a/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfoFactory.java
+++ b/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfoFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.opentelemetry;
+
+import com.datastax.driver.core.tracing.NoopTracingInfoFactory;
+import com.datastax.driver.core.tracing.TracingInfo;
+import com.datastax.driver.core.tracing.TracingInfoFactory;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+
+public class OpenTelemetryTracingInfoFactory implements TracingInfoFactory {
+  private final Tracer tracer; // OpenTelemetry Tracer object
+
+  public OpenTelemetryTracingInfoFactory(final Tracer tracer) {
+    this.tracer = tracer;
+  }
+
+  @Override
+  public TracingInfo buildTracingInfo() {
+    final Context current = Context.current();
+    return new OpenTelemetryTracingInfo(tracer, current);
+  }
+
+  @Override
+  public TracingInfo buildTracingInfo(TracingInfo parent) {
+    if (parent instanceof OpenTelemetryTracingInfo) {
+      final OpenTelemetryTracingInfo castedParent = (OpenTelemetryTracingInfo) parent;
+      return new OpenTelemetryTracingInfo(castedParent.getTracer(), castedParent.getContext());
+    }
+
+    return new NoopTracingInfoFactory().buildTracingInfo();
+  }
+
+  public TracingInfo buildTracingInfo(Span parent) {
+    final Context current = Context.current().with(parent);
+    return new OpenTelemetryTracingInfo(tracer, current);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <module>driver-examples</module>
         <module>driver-tests</module>
         <module>driver-dist</module>
+        <module>driver-opentelemetry</module>
     </modules>
 
     <properties>
@@ -127,6 +128,12 @@
             <dependency>
                 <groupId>com.scylladb</groupId>
                 <artifactId>scylla-driver-extras</artifactId>
+                <version>${project.parent.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.scylladb</groupId>
+                <artifactId>scylla-driver-opentelemetry</artifactId>
                 <version>${project.parent.version}</version>
             </dependency>
 
@@ -724,6 +731,9 @@
                                     <artifactId>java18</artifactId>
                                     <version>1.0</version>
                                 </signature>
+                                <excludeDependencies>
+                                    <excludeDependency>io.opentelemetry:*</excludeDependency>
+                                </excludeDependencies>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
The PR introduces ability to trace the basic driver operation using OpenTelemetry standard. Every request has its corresponding OTel Span, which at this moment contains time taken to process the request, and request status (success or failure).

The implementation was tested with standard tests run by Maven during build, as well as by checking it performance using the added `ZipkinUsage` example, which is meant to be run using `docker compose up` and `runOpenTelemetryExample.sh` in `driver-examples` directory.