### PR TITLE
Opentelemetry precision level

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/PrecisionLevel.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/PrecisionLevel.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.core.tracing;
+
+/** The precision level of tracing data that is to be collected. May be extended in the future. */
+public enum PrecisionLevel {
+  // Enum elements must be listed in ascending order of precision level (i.e. each next element
+  // listed adds some new information).
+  NORMAL,
+  FULL;
+}

--- a/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfoFactory.java
+++ b/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfoFactory.java
@@ -17,6 +17,7 @@
 package com.datastax.driver.opentelemetry;
 
 import com.datastax.driver.core.tracing.NoopTracingInfoFactory;
+import com.datastax.driver.core.tracing.PrecisionLevel;
 import com.datastax.driver.core.tracing.TracingInfo;
 import com.datastax.driver.core.tracing.TracingInfoFactory;
 import io.opentelemetry.api.trace.Span;
@@ -24,23 +25,30 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 
 public class OpenTelemetryTracingInfoFactory implements TracingInfoFactory {
-  private final Tracer tracer; // OpenTelemetry Tracer object
+  private final Tracer tracer;
+  private final PrecisionLevel precision;
 
   public OpenTelemetryTracingInfoFactory(final Tracer tracer) {
+    this(tracer, PrecisionLevel.NORMAL);
+  }
+
+  public OpenTelemetryTracingInfoFactory(final Tracer tracer, final PrecisionLevel precision) {
     this.tracer = tracer;
+    this.precision = precision;
   }
 
   @Override
   public TracingInfo buildTracingInfo() {
     final Context current = Context.current();
-    return new OpenTelemetryTracingInfo(tracer, current);
+    return new OpenTelemetryTracingInfo(tracer, current, precision);
   }
 
   @Override
   public TracingInfo buildTracingInfo(TracingInfo parent) {
     if (parent instanceof OpenTelemetryTracingInfo) {
       final OpenTelemetryTracingInfo castedParent = (OpenTelemetryTracingInfo) parent;
-      return new OpenTelemetryTracingInfo(castedParent.getTracer(), castedParent.getContext());
+      return new OpenTelemetryTracingInfo(
+          castedParent.getTracer(), castedParent.getContext(), castedParent.getPrecision());
     }
 
     return new NoopTracingInfoFactory().buildTracingInfo();
@@ -48,6 +56,6 @@ public class OpenTelemetryTracingInfoFactory implements TracingInfoFactory {
 
   public TracingInfo buildTracingInfo(Span parent) {
     final Context current = Context.current().with(parent);
-    return new OpenTelemetryTracingInfo(tracer, current);
+    return new OpenTelemetryTracingInfo(tracer, current, precision);
   }
 }


### PR DESCRIPTION
The PR introduces the ability of choosing the precision level that indicates how much tracing information would be collected during the session. Precision level may be chosen among NORMAL and FULL level (further levels may be added in the future). Tracing with normal level precision collect only the most important data, while those with full level - all the possible data including redundant and sensitive information.

