### PR TITLE
Scylla tracing negotiation

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -39,6 +39,8 @@ import com.datastax.driver.core.policies.Policies;
 import com.datastax.driver.core.policies.ReconnectionPolicy;
 import com.datastax.driver.core.policies.RetryPolicy;
 import com.datastax.driver.core.policies.SpeculativeExecutionPolicy;
+import com.datastax.driver.core.tracing.NoopTracingInfoFactory;
+import com.datastax.driver.core.tracing.TracingInfoFactory;
 import com.datastax.driver.core.utils.MoreFutures;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Functions;
@@ -142,6 +144,8 @@ public class Cluster implements Closeable {
 
   final Manager manager;
 
+  private TracingInfoFactory tracingInfoFactory = new NoopTracingInfoFactory();
+
   /**
    * Constructs a new Cluster instance.
    *
@@ -191,6 +195,25 @@ public class Cluster implements Closeable {
     System.out.println("===== Using optimized driver!!! =====");
     logger.info("===== Using optimized driver!!! =====");
     this.manager = new Manager(name, contactPoints, configuration, listeners);
+  }
+
+  /**
+   * The tracingInfo factory class used by this Cluster.
+   *
+   * @return the factory used currently by this Cluster.
+   */
+  public TracingInfoFactory getTracingInfoFactory() {
+    return tracingInfoFactory;
+  }
+
+  /**
+   * Sets desired factory for tracing information for this Cluster. By default it is {@link
+   * com.datastax.driver.core.tracing.NoopTracingInfoFactory}
+   *
+   * @param tracingInfoFactory the factory to be set for this Session.
+   */
+  public void setTracingInfoFactory(TracingInfoFactory tracingInfoFactory) {
+    this.tracingInfoFactory = tracingInfoFactory;
   }
 
   /**

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -30,6 +30,7 @@ import com.datastax.driver.core.exceptions.AuthenticationException;
 import com.datastax.driver.core.exceptions.BusyPoolException;
 import com.datastax.driver.core.exceptions.ConnectionException;
 import com.datastax.driver.core.exceptions.UnsupportedProtocolVersionException;
+import com.datastax.driver.core.tracing.NoopTracingInfoFactory;
 import com.datastax.driver.core.utils.MoreFutures;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
@@ -244,6 +245,10 @@ class HostConnectionPool implements Connection.Owner {
     this.timeoutsExecutor = manager.getCluster().manager.connectionFactory.eventLoopGroup.next();
   }
 
+  protected boolean isTracingRequested() {
+    return !(manager.getTracingInfoFactory() instanceof NoopTracingInfoFactory);
+  }
+
   /**
    * @param reusedConnection an existing connection (from a reconnection attempt) that we want to
    *     reuse as part of this pool. Might be null or already used by another pool.
@@ -321,14 +326,15 @@ class HostConnectionPool implements Connection.Owner {
           }
         }
 
-        ListenableFuture<Void> connectionFuture = connection.initAsync(shardId, serverPort);
+        ListenableFuture<Void> connectionFuture =
+            connection.initAsync(shardId, serverPort, isTracingRequested());
         connectionFutures.add(handleErrors(connectionFuture, initExecutor));
 
         shardConnectionIndex++;
       }
     } else {
       for (Connection connection : newConnections) {
-        ListenableFuture<Void> connectionFuture = connection.initAsync();
+        ListenableFuture<Void> connectionFuture = connection.initAsync(isTracingRequested());
         connectionFutures.add(handleErrors(connectionFuture, initExecutor));
       }
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/Session.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Session.java
@@ -49,14 +49,6 @@ import java.util.Map;
 public interface Session extends Closeable {
 
   /**
-   * Sets desired factory for tracing information for this Session. By default it is {@link
-   * com.datastax.driver.core.tracing.NoopTracingInfoFactory}
-   *
-   * @param tracingInfoFactory the factory to be set for this Session.
-   */
-  void setTracingInfoFactory(TracingInfoFactory tracingInfoFactory);
-
-  /**
    * The tracingInfo factory class used by this Session.
    *
    * @return the factory used currently by this Session.

--- a/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -29,7 +29,6 @@ import com.datastax.driver.core.exceptions.UnsupportedProtocolVersionException;
 import com.datastax.driver.core.policies.LoadBalancingPolicy;
 import com.datastax.driver.core.policies.ReconnectionPolicy;
 import com.datastax.driver.core.policies.SpeculativeExecutionPolicy;
-import com.datastax.driver.core.tracing.NoopTracingInfoFactory;
 import com.datastax.driver.core.tracing.TracingInfo;
 import com.datastax.driver.core.tracing.TracingInfoFactory;
 import com.datastax.driver.core.utils.MoreFutures;
@@ -72,8 +71,6 @@ class SessionManager extends AbstractSession {
   private volatile boolean isInit;
   private volatile boolean isClosing;
 
-  private TracingInfoFactory tracingInfoFactory = new NoopTracingInfoFactory();
-
   // Package protected, only Cluster should construct that.
   SessionManager(Cluster cluster) {
     this.cluster = cluster;
@@ -82,13 +79,8 @@ class SessionManager extends AbstractSession {
   }
 
   @Override
-  public void setTracingInfoFactory(TracingInfoFactory tracingInfoFactory) {
-    this.tracingInfoFactory = tracingInfoFactory;
-  }
-
-  @Override
   public TracingInfoFactory getTracingInfoFactory() {
-    return tracingInfoFactory;
+    return cluster.getTracingInfoFactory();
   }
 
   @Override
@@ -170,7 +162,7 @@ class SessionManager extends AbstractSession {
       // Because of the way the future is built, we need another 'proxy' future that we can return
       // now.
       final ChainedResultSetFuture chainedFuture = new ChainedResultSetFuture();
-      final TracingInfo tracingInfo = tracingInfoFactory.buildTracingInfo();
+      final TracingInfo tracingInfo = getTracingInfoFactory().buildTracingInfo();
       this.initAsync()
           .addListener(
               new Runnable() {
@@ -746,7 +738,7 @@ class SessionManager extends AbstractSession {
   }
 
   void execute(final RequestHandler.Callback callback, final Statement statement) {
-    final TracingInfo tracingInfo = tracingInfoFactory.buildTracingInfo();
+    final TracingInfo tracingInfo = getTracingInfoFactory().buildTracingInfo();
     execute(callback, statement, tracingInfo);
   }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
@@ -295,11 +295,6 @@ public class AsyncQueryTest extends CCMTestsSupport {
     }
 
     @Override
-    public void setTracingInfoFactory(TracingInfoFactory tracingInfoFactory) {
-      session.setTracingInfoFactory(tracingInfoFactory);
-    }
-
-    @Override
     public TracingInfoFactory getTracingInfoFactory() {
       return session.getTracingInfoFactory();
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/DelegatingClusterTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DelegatingClusterTest.java
@@ -29,7 +29,8 @@ import org.mockito.invocation.Invocation;
 import org.testng.annotations.Test;
 
 public class DelegatingClusterTest {
-  private static final Set<String> NON_DELEGATED_METHODS = ImmutableSet.of("getClusterName");
+  private static final Set<String> NON_DELEGATED_METHODS =
+      ImmutableSet.of("getClusterName", "setTracingInfoFactory", "getTracingInfoFactory");
 
   /**
    * Checks that all methods of {@link DelegatingCluster} invoke their counterpart in {@link

--- a/driver-examples/src/main/java/com/datastax/driver/examples/opentelemetry/ZipkinUsage.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/opentelemetry/ZipkinUsage.java
@@ -85,13 +85,13 @@ public class ZipkinUsage {
 
     System.out.printf("Connected to cluster: %s%n", cluster.getMetadata().getClusterName());
 
-    session = cluster.connect();
-
     OpenTelemetry openTelemetry =
         OpenTelemetryConfiguration.initializeForZipkin(ZIPKIN_CONTACT_POINT, ZIPKIN_PORT);
     tracer = openTelemetry.getTracerProvider().get("this");
     TracingInfoFactory tracingInfoFactory = new OpenTelemetryTracingInfoFactory(tracer);
-    session.setTracingInfoFactory(tracingInfoFactory);
+    cluster.setTracingInfoFactory(tracingInfoFactory);
+
+    session = cluster.connect();
   }
 
   /** Creates the schema (keyspace) and tables for this example. */


### PR DESCRIPTION
Introduces negotiations with Scylla about whether tracing information should be gathered and sent along. Decision is made based on tracer being provided or not: if user provides tracer to session, then the tracing at Scylla will be gathered.