### PR TITLE
fix OpenTelemetryTest and BasicTracingTest

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfoFactory.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfoFactory.java
@@ -18,10 +18,12 @@ package com.datastax.driver.core.tracing;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 public class TestTracingInfoFactory implements TracingInfoFactory {
   private final PrecisionLevel precision;
-  private Collection<TracingInfo> spans = new ArrayList();
+  private Collection<TracingInfo> spans =
+      Collections.synchronizedList(new ArrayList<TracingInfo>());
 
   public TestTracingInfoFactory() {
     this.precision = PrecisionLevel.NORMAL;

--- a/driver-opentelemetry/src/test/java/com/datastax/driver/opentelemetry/OpenTelemetryTest.java
+++ b/driver-opentelemetry/src/test/java/com/datastax/driver/opentelemetry/OpenTelemetryTest.java
@@ -36,6 +36,7 @@ import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -45,8 +46,10 @@ import org.testng.annotations.Test;
 public class OpenTelemetryTest extends CCMTestsSupport {
   /** Collects and saves spans. */
   private static final class SpansCollector implements SpanProcessor {
-    final Collection<ReadableSpan> startedSpans = new ArrayList<>();
-    final Collection<ReadableSpan> spans = new ArrayList<>();
+    final Collection<ReadableSpan> startedSpans =
+        Collections.synchronizedList(new ArrayList<ReadableSpan>());
+    final Collection<ReadableSpan> spans =
+        Collections.synchronizedList(new ArrayList<ReadableSpan>());
 
     @Override
     public void onStart(Context parentContext, ReadWriteSpan span) {


### PR DESCRIPTION
The PR introduces fixes in Open Telemetry integration tests: BasicTracingTest and OpenTelemetryTest.  ArrayLists are replaced with concurrent lists to avoid problems while these structures may me updated by multiple threads.