### PR TITLE
Add information received in response to prepare to the trace

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
@@ -74,6 +74,8 @@ public class BoundStatement extends Statement
 
   private ByteBuffer routingKey;
 
+  private final String operationType;
+
   /**
    * Creates a new {@code BoundStatement} from the provided prepared statement.
    *
@@ -92,16 +94,22 @@ public class BoundStatement extends Statement
       this.setSerialConsistencyLevel(statement.getSerialConsistencyLevel());
     if (statement.isTracing()) this.enableTracing();
     if (statement.getRetryPolicy() != null) this.setRetryPolicy(statement.getRetryPolicy());
+    this.operationType = statement.getOperationType();
     if (statement.getOutgoingPayload() != null)
       this.setOutgoingPayload(statement.getOutgoingPayload());
     else
       // propagate incoming payload as outgoing payload, if no outgoing payload has been explicitly
       // set
       this.setOutgoingPayload(statement.getIncomingPayload());
+
     this.codecRegistry = statement.getCodecRegistry();
     if (statement.isIdempotent() != null) {
       this.setIdempotent(statement.isIdempotent());
     }
+  }
+
+  public String getOperationType() {
+    return operationType;
   }
 
   @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/DefaultPreparedStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DefaultPreparedStatement.java
@@ -42,6 +42,7 @@ public class DefaultPreparedStatement implements PreparedStatement {
   final Cluster cluster;
   final boolean isLWT;
   final Token.Factory partitioner;
+  final String operationType;
 
   volatile ByteBuffer routingKey;
 
@@ -66,10 +67,12 @@ public class DefaultPreparedStatement implements PreparedStatement {
     if (incomingPayload != null && incomingPayload.containsKey("opentelemetry")) {
       Map<String, ByteBuffer> incomingPayloadCopy =
           new HashMap<String, ByteBuffer>(incomingPayload);
-      incomingPayloadCopy.remove("opentelemetry");
+      ByteBuffer buf = incomingPayloadCopy.remove("opentelemetry");
+      this.operationType = new String(buf.array(), buf.position(), buf.limit() - buf.position());
       if (incomingPayloadCopy.isEmpty()) this.incomingPayload = null;
       else this.incomingPayload = ImmutableMap.copyOf(incomingPayloadCopy);
     } else {
+      this.operationType = null;
       this.incomingPayload = incomingPayload;
     }
     this.cluster = cluster;
@@ -323,5 +326,11 @@ public class DefaultPreparedStatement implements PreparedStatement {
   @Override
   public boolean isLWT() {
     return isLWT;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getOperationType() {
+    return operationType;
   }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/PreparedStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PreparedStatement.java
@@ -361,4 +361,7 @@ public interface PreparedStatement {
 
   /** Whether a prepared statement is LWT statement */
   public boolean isLWT();
+
+  /** Type of prepared operation (e.g. SELECT) */
+  public String getOperationType();
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -175,6 +175,7 @@ class RequestHandler {
     String keyspace = null;
     String partitionKey = null;
     String table = null;
+    String operationType = null;
 
     if (statement instanceof BatchStatement) {
       statementType = "batch";
@@ -190,6 +191,7 @@ class RequestHandler {
       statementType = "prepared";
       statementText = ((BoundStatement) statement).statement.getQueryString();
       keyspace = ((BoundStatement) statement).getKeyspace();
+      operationType = ((BoundStatement) statement).getOperationType();
 
       ColumnDefinitions boundColumns =
           ((BoundStatement) statement).statement.getPreparedId().boundValuesMetadata.variables;
@@ -226,6 +228,7 @@ class RequestHandler {
     if (keyspace != null) this.tracingInfo.setKeyspace(keyspace);
     if (partitionKey != null) this.tracingInfo.setPartitionKey(partitionKey);
     if (table != null) this.tracingInfo.setTable(table);
+    if (operationType != null) this.tracingInfo.setOperationType(operationType);
   }
 
   void sendRequest() {

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
@@ -76,6 +76,9 @@ public class NoopTracingInfoFactory implements TracingInfoFactory {
     public void setTable(String table) {}
 
     @Override
+    public void setOperationType(String operationType) {}
+
+    @Override
     public void setReplicas(String replicas) {}
 
     @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
@@ -156,6 +156,13 @@ public interface TracingInfo {
   void setTable(String table);
 
   /**
+   * Adds provided operation type (e.g. SELECT) to the trace.
+   *
+   * @param operationType the operation type to be set.
+   */
+  void setOperationType(String operationType);
+
+  /**
    * Adds provided list of contacted replicas to the trace.
    *
    * @param replicas the list of contacted replicas to be set.

--- a/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfo.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfo.java
@@ -50,6 +50,7 @@ public class TestTracingInfo implements TracingInfo {
   private String keyspace;
   private String partitionKey;
   private String table;
+  private String operationType;
   private String replicas;
 
   public TestTracingInfo(PrecisionLevel precision) {
@@ -152,6 +153,11 @@ public class TestTracingInfo implements TracingInfo {
   @Override
   public void setTable(String table) {
     this.table = table;
+  }
+
+  @Override
+  public void setOperationType(String operationType) {
+    this.operationType = operationType;
   }
 
   @Override
@@ -261,6 +267,10 @@ public class TestTracingInfo implements TracingInfo {
 
   public String getTable() {
     return table;
+  }
+
+  public String getOperationType() {
+    return operationType;
   }
 
   public String getReplicas() {

--- a/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfo.java
+++ b/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfo.java
@@ -179,6 +179,12 @@ public class OpenTelemetryTracingInfo implements TracingInfo {
   }
 
   @Override
+  public void setOperationType(String operationType) {
+    assertStarted();
+    span.setAttribute("db.operation", operationType);
+  }
+
+  @Override
   public void setReplicas(String replicas) {
     assertStarted();
     span.setAttribute("db.scylla.replicas", replicas);


### PR DESCRIPTION
The PR introduces parsing operation type received in custom payload in response to prepare and setting it as a tag of bound statement. The incoming payload of prepared statement is propagated as outgoing payload if no outgoing payload has been explicitly set but then operation type is removed from the payload that is propagated.