### PR TITLE
add list of contacted replicas received in custom payload to the trace

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/DefaultPreparedStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DefaultPreparedStatement.java
@@ -26,6 +26,7 @@ import static com.datastax.driver.core.ProtocolVersion.V4;
 import com.datastax.driver.core.policies.RetryPolicy;
 import com.google.common.collect.ImmutableMap;
 import java.nio.ByteBuffer;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -62,7 +63,15 @@ public class DefaultPreparedStatement implements PreparedStatement {
     this.preparedId = id;
     this.query = query;
     this.queryKeyspace = queryKeyspace;
-    this.incomingPayload = incomingPayload;
+    if (incomingPayload != null && incomingPayload.containsKey("opentelemetry")) {
+      Map<String, ByteBuffer> incomingPayloadCopy =
+          new HashMap<String, ByteBuffer>(incomingPayload);
+      incomingPayloadCopy.remove("opentelemetry");
+      if (incomingPayloadCopy.isEmpty()) this.incomingPayload = null;
+      else this.incomingPayload = ImmutableMap.copyOf(incomingPayloadCopy);
+    } else {
+      this.incomingPayload = incomingPayload;
+    }
     this.cluster = cluster;
     this.isLWT = isLWT;
     this.partitioner = partitioner;

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -76,6 +76,7 @@ class RequestHandler {
 
   private static final int STATEMENT_MAX_LENGTH = 1000;
   private static final int PARTITION_KEY_MAX_LENGTH = 1000;
+  private static final int REPLICAS_MAX_LENGTH = 1000;
 
   final String id;
 
@@ -1183,6 +1184,23 @@ class RequestHandler {
 
     private void setFinalResult(Connection connection, Message.Response response) {
       parentTracingInfo.setRetryCount(retryCount());
+
+      if (response.getCustomPayload() != null
+          && response.getCustomPayload().containsKey("opentelemetry")) {
+        ByteBuffer buf = response.getCustomPayload().get("opentelemetry");
+        int rep = buf.getInt();
+        StringBuilder replicasBuilder = new StringBuilder(REPLICAS_MAX_LENGTH);
+        for (int i = 0; i < rep; i++) {
+          int addrSize = (buf.get() & 0xFF); // convert to unsigned int
+          if (i > 0) replicasBuilder.append(", ");
+          for (int j = 0; j < addrSize; j++) {
+            if (j > 0) replicasBuilder.append('.');
+            replicasBuilder.append(buf.get() & 0xFF); // convert to unsigned int
+          }
+        }
+        parentTracingInfo.setReplicas(replicasBuilder.toString());
+      }
+
       parentTracingInfo.tracingFinished();
       RequestHandler.this.setFinalResult(this, connection, response);
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
@@ -76,6 +76,9 @@ public class NoopTracingInfoFactory implements TracingInfoFactory {
     public void setTable(String table) {}
 
     @Override
+    public void setReplicas(String replicas) {}
+
+    @Override
     public void recordException(Exception exception) {}
 
     @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
@@ -156,6 +156,13 @@ public interface TracingInfo {
   void setTable(String table);
 
   /**
+   * Adds provided list of contacted replicas to the trace.
+   *
+   * @param replicas the list of contacted replicas to be set.
+   */
+  void setReplicas(String replicas);
+
+  /**
    * Records in the trace that the provided exception occured.
    *
    * @param exception the exception to be recorded.

--- a/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfo.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfo.java
@@ -50,6 +50,7 @@ public class TestTracingInfo implements TracingInfo {
   private String keyspace;
   private String partitionKey;
   private String table;
+  private String replicas;
 
   public TestTracingInfo(PrecisionLevel precision) {
     this.precision = precision;
@@ -154,6 +155,11 @@ public class TestTracingInfo implements TracingInfo {
   }
 
   @Override
+  public void setReplicas(String replicas) {
+    this.replicas = replicas;
+  }
+
+  @Override
   public void recordException(Exception exception) {
     if (this.exceptions == null) {
       this.exceptions = new ArrayList();
@@ -255,6 +261,10 @@ public class TestTracingInfo implements TracingInfo {
 
   public String getTable() {
     return table;
+  }
+
+  public String getReplicas() {
+    return replicas;
   }
 
   public StatusCode getStatusCode() {

--- a/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfo.java
+++ b/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfo.java
@@ -178,6 +178,12 @@ public class OpenTelemetryTracingInfo implements TracingInfo {
     span.setAttribute("db.scylla.table", table);
   }
 
+  @Override
+  public void setReplicas(String replicas) {
+    assertStarted();
+    span.setAttribute("db.scylla.replicas", replicas);
+  }
+
   private io.opentelemetry.api.trace.StatusCode mapStatusCode(StatusCode code) {
     switch (code) {
       case OK:


### PR DESCRIPTION
The PR introduces parsing list of contacted replicas received in custom payload and adding it to the trace. The incoming payload of prepared statement is propagated as outgoing payload if no outgoing payload has been explicitly set but then telemetry data is removed from the payload that is propagated.