### PR TITLE
Opentelemetry dma reads

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -1204,6 +1204,7 @@ class RequestHandler {
         parentTracingInfo.setReplicas(replicasBuilder.toString());
         parentTracingInfo.setCacheReadCount(buf.getInt());
         parentTracingInfo.setDmaReadCount(buf.getInt());
+        parentTracingInfo.setDmaBytesRead(buf.getInt());
       }
 
       parentTracingInfo.tracingFinished();

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -1203,6 +1203,7 @@ class RequestHandler {
         }
         parentTracingInfo.setReplicas(replicasBuilder.toString());
         parentTracingInfo.setCacheReadCount(buf.getInt());
+        parentTracingInfo.setDmaReadCount(buf.getInt());
       }
 
       parentTracingInfo.tracingFinished();

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -1202,6 +1202,7 @@ class RequestHandler {
           }
         }
         parentTracingInfo.setReplicas(replicasBuilder.toString());
+        parentTracingInfo.setCacheReadCount(buf.getInt());
       }
 
       parentTracingInfo.tracingFinished();

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
@@ -88,6 +88,9 @@ public class NoopTracingInfoFactory implements TracingInfoFactory {
     public void setDmaReadCount(int dmaReadCount) {}
 
     @Override
+    public void setDmaBytesRead(int dmaBytesRead) {}
+
+    @Override
     public void recordException(Exception exception) {}
 
     @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
@@ -82,6 +82,9 @@ public class NoopTracingInfoFactory implements TracingInfoFactory {
     public void setReplicas(String replicas) {}
 
     @Override
+    public void setCacheReadCount(int cacheReadCount) {}
+
+    @Override
     public void recordException(Exception exception) {}
 
     @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
@@ -85,6 +85,9 @@ public class NoopTracingInfoFactory implements TracingInfoFactory {
     public void setCacheReadCount(int cacheReadCount) {}
 
     @Override
+    public void setDmaReadCount(int dmaReadCount) {}
+
+    @Override
     public void recordException(Exception exception) {}
 
     @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
@@ -184,6 +184,13 @@ public interface TracingInfo {
   void setDmaReadCount(int dmaReadCount);
 
   /**
+   * Adds provided counter of bytes read in DMA reads to the trace.
+   *
+   * @param dmaBytesRead the counter to be set.
+   */
+  void setDmaBytesRead(int dmaBytesRead);
+
+  /**
    * Records in the trace that the provided exception occured.
    *
    * @param exception the exception to be recorded.

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
@@ -170,6 +170,13 @@ public interface TracingInfo {
   void setReplicas(String replicas);
 
   /**
+   * Adds provided cache reads counter to the trace.
+   *
+   * @param cacheReadCount the counter to be set.
+   */
+  void setCacheReadCount(int cacheReadCount);
+
+  /**
    * Records in the trace that the provided exception occured.
    *
    * @param exception the exception to be recorded.

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
@@ -177,6 +177,13 @@ public interface TracingInfo {
   void setCacheReadCount(int cacheReadCount);
 
   /**
+   * Adds provided DMA reads counter to the trace.
+   *
+   * @param dmaReadCount the counter to be set.
+   */
+  void setDmaReadCount(int dmaReadCount);
+
+  /**
    * Records in the trace that the provided exception occured.
    *
    * @param exception the exception to be recorded.

--- a/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfo.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfo.java
@@ -54,6 +54,7 @@ public class TestTracingInfo implements TracingInfo {
   private String replicas;
   private Integer cacheReadCount;
   private Integer dmaReadCount;
+  private Integer dmaBytesRead;
 
   public TestTracingInfo(PrecisionLevel precision) {
     this.precision = precision;
@@ -178,6 +179,11 @@ public class TestTracingInfo implements TracingInfo {
   }
 
   @Override
+  public void setDmaBytesRead(int dmaBytesRead) {
+    this.dmaBytesRead = dmaBytesRead;
+  }
+
+  @Override
   public void recordException(Exception exception) {
     if (this.exceptions == null) {
       this.exceptions = new ArrayList();
@@ -295,6 +301,10 @@ public class TestTracingInfo implements TracingInfo {
 
   public Integer getDmaReadCount() {
     return dmaReadCount;
+  }
+
+  public Integer getDmaBytesRead() {
+    return dmaBytesRead;
   }
 
   public StatusCode getStatusCode() {

--- a/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfo.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfo.java
@@ -52,6 +52,7 @@ public class TestTracingInfo implements TracingInfo {
   private String table;
   private String operationType;
   private String replicas;
+  private Integer cacheReadCount;
 
   public TestTracingInfo(PrecisionLevel precision) {
     this.precision = precision;
@@ -166,6 +167,11 @@ public class TestTracingInfo implements TracingInfo {
   }
 
   @Override
+  public void setCacheReadCount(int cacheReadCount) {
+    this.cacheReadCount = cacheReadCount;
+  }
+
+  @Override
   public void recordException(Exception exception) {
     if (this.exceptions == null) {
       this.exceptions = new ArrayList();
@@ -275,6 +281,10 @@ public class TestTracingInfo implements TracingInfo {
 
   public String getReplicas() {
     return replicas;
+  }
+
+  public Integer getcacheReadCount() {
+    return cacheReadCount;
   }
 
   public StatusCode getStatusCode() {

--- a/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfo.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfo.java
@@ -53,6 +53,7 @@ public class TestTracingInfo implements TracingInfo {
   private String operationType;
   private String replicas;
   private Integer cacheReadCount;
+  private Integer dmaReadCount;
 
   public TestTracingInfo(PrecisionLevel precision) {
     this.precision = precision;
@@ -172,6 +173,11 @@ public class TestTracingInfo implements TracingInfo {
   }
 
   @Override
+  public void setDmaReadCount(int dmaReadCount) {
+    this.dmaReadCount = dmaReadCount;
+  }
+
+  @Override
   public void recordException(Exception exception) {
     if (this.exceptions == null) {
       this.exceptions = new ArrayList();
@@ -285,6 +291,10 @@ public class TestTracingInfo implements TracingInfo {
 
   public Integer getcacheReadCount() {
     return cacheReadCount;
+  }
+
+  public Integer getDmaReadCount() {
+    return dmaReadCount;
   }
 
   public StatusCode getStatusCode() {

--- a/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfo.java
+++ b/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfo.java
@@ -202,6 +202,12 @@ public class OpenTelemetryTracingInfo implements TracingInfo {
     span.setAttribute("db.scylla.dma_read_count", dmaReadCount);
   }
 
+  @Override
+  public void setDmaBytesRead(int dmaBytesRead) {
+    assertStarted();
+    span.setAttribute("db.scylla.dma_bytes_read", dmaBytesRead);
+  }
+
   private io.opentelemetry.api.trace.StatusCode mapStatusCode(StatusCode code) {
     switch (code) {
       case OK:

--- a/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfo.java
+++ b/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfo.java
@@ -196,6 +196,12 @@ public class OpenTelemetryTracingInfo implements TracingInfo {
     span.setAttribute("db.scylla.cache_read_count", cacheReadCount);
   }
 
+  @Override
+  public void setDmaReadCount(int dmaReadCount) {
+    assertStarted();
+    span.setAttribute("db.scylla.dma_read_count", dmaReadCount);
+  }
+
   private io.opentelemetry.api.trace.StatusCode mapStatusCode(StatusCode code) {
     switch (code) {
       case OK:

--- a/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfo.java
+++ b/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfo.java
@@ -190,6 +190,12 @@ public class OpenTelemetryTracingInfo implements TracingInfo {
     span.setAttribute("db.scylla.replicas", replicas);
   }
 
+  @Override
+  public void setCacheReadCount(int cacheReadCount) {
+    assertStarted();
+    span.setAttribute("db.scylla.cache_read_count", cacheReadCount);
+  }
+
   private io.opentelemetry.api.trace.StatusCode mapStatusCode(StatusCode code) {
     switch (code) {
       case OK:


### PR DESCRIPTION
The PR introduces attaching to the trace new replica-side tags: `dma_read_count` and `dma_bytes_read` based on the information received from coordinator in custom payload.